### PR TITLE
set cython to <3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,14 +78,14 @@ setup(
     setup_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=42',
-        'cython>=0.29.15',
+        'cython<3',
         'numpy>=1.16.6', # select this version for Py2/3 compatible
         'scipy>=1.2.3'   # select this version for Py2/3 compatible
     ],
     install_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=42',
-        'cython>=0.29.15',
+        'cython<3',
         'numpy>=1.16.6', # select this version for Py2/3 compatible
         'scipy>=1.2.3'   # select this version for Py2/3 compatible
     ],


### PR DESCRIPTION
This library currently blows up when trying to install because of a new cython 3.0 version